### PR TITLE
[FEAT] Endpoint útil de usuario para dar de alta usuarios bajo diferentes escenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,26 @@ Referencias de como usarlo: [Guia del Changelog](./CHANGELOG.md#-guía-del-chang
 
 ---
 
+# [0.4.0-alpha] - 2026-03-26
+## Rodrigo Mijangos [Issue #X](https://github.com/RodrigoMijangos/recolecta_web/issues/X)
+### Added
+- Implementación de entidades para modelado de datos a utilizar en PostgreSQL conforme a ciudadanos.
+- Ruta e implementación de lógica para registrar ciudadanos.
+- Flexibilidad para registrar ciudadanos con o sin geolocalización, tokens FCM son obligatorios.
+- Repositorio de ciudadanos usando PostgreSQL.
+- Caso de uso para actualizar coordenadas.
+- Creación del controlador de ciudadanos con endpoint para registrar ciudadanos y actualizar coordenadas.
+
+### Changed
+- Alta en las dependencias de la infraestructura.
+- Configuración de archivo main para incializar Redis y cerrarlo al finalizar la ejecución.
+
 # 0.3.0-alpha - 2026-03-25
 ## Rodrigo Mijangos [Issue #24](https://github.com/RodrigoMijangos/recolecta_web/issues/24)
 ### Added
 - Implementación de Caso de uso y Endopoint para mandar notificaciones a FCM.
 - Implementación de Caso de uso y Endopoint para guardar logs de notificaciones push.
 - Logging de mensajes de error en el servicio de notificaciones push.
-
 
 # 0.2.0-alpha - 2026-03-24
 ## Rodrigo Mijangos [Issue #23](https://github.com/RodrigoMijangos/recolecta_web/issues/23)

--- a/dependencies.go
+++ b/dependencies.go
@@ -45,7 +45,7 @@ import (
 
 	anomalia "github.com/vicpoo/API_recolecta/src/anomalia/infrastructure"
 	incidencia "github.com/vicpoo/API_recolecta/src/incidencia/infrastructure"
-	_ "github.com/vicpoo/API_recolecta/src/notificacion/infrastructure"
+	pushNotifInfra "github.com/vicpoo/API_recolecta/src/notificacion/infrastructure"
 	reporteConductor "github.com/vicpoo/API_recolecta/src/reporte_conductor/infrastructure"
 	registroMantenimiento "github.com/vicpoo/API_recolecta/src/registro_mantenimiento/infrastructure"
 	reporteFallaCritica "github.com/vicpoo/API_recolecta/src/reporte_falla_critica/infrastructure"
@@ -60,6 +60,7 @@ import (
 	coloniaHttp "github.com/vicpoo/API_recolecta/src/colonia/infrastructure/http"
 	rolInfra "github.com/vicpoo/API_recolecta/src/rol/infrastructure"
 	usuarioInfra "github.com/vicpoo/API_recolecta/src/usuario/infrastructure"
+	ciudadanoInfra "github.com/vicpoo/API_recolecta/src/ciudadano/infrastructure"
 
 
 
@@ -450,7 +451,10 @@ domicilioController.RegisterRoutes(engine)
 usuarioDeps := usuarioInfra.NewUsuarioDependencies(db)
 usuarioInfra.RegisterUsuarioRoutes(engine, usuarioDeps)
 
-rolController := rolInfra.NewRolDependencies(db)
+	// Adicion de ciudadanos como parte de usuarios
+
+	ciudadanoDeps := ciudadanoInfra.NewCiudadanoDependencies(db, core.GetRedis())
+	ciudadanoInfra.RegisterCiudadanoRoutes(engine, ciudadanoDeps)
 rolInfra.RegisterRolRoutes(engine, rolController)
 
 anomaliaRoutes := anomalia.NewAnomaliaRouter(engine)
@@ -488,6 +492,9 @@ anomaliaRoutes := anomalia.NewAnomaliaRouter(engine)
 	tipoMantenimientoRoutes := tipoMantenimiento.NewTipoMantenimientoRouter(engine)
 
 	tipoMantenimientoRoutes.Run()
+
+	pushNotificationRoutes := pushNotifInfra.NewPushNotificationRouter(engine)
+	pushNotificationRoutes.Run()
 
 	core.RegisterHealthEndpoint(engine)
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,21 @@
 package main
 
+import (
+	"log"
 
+	"github.com/vicpoo/API_recolecta/src/core"
+)
 
 func main() {
-	InitDependencies()
+	if _, err := core.ConnectRedis(); err != nil {
+		log.Fatalf("failed to initialize redis: %v", err)
+	}
+	defer func() {
+		if closeErr := core.CloseRedis(); closeErr != nil {
+			log.Printf("failed to close redis: %v", closeErr)
+		}
+	}()
 
+	InitDependencies()
 }
+

--- a/src/ciudadano/application/register_ciudadano.go
+++ b/src/ciudadano/application/register_ciudadano.go
@@ -1,0 +1,75 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+	"github.com/vicpoo/API_recolecta/src/ciudadano/domain/entities"
+	"github.com/vicpoo/API_recolecta/src/ciudadano/domain/ports"
+)
+
+type RegisterCiudadanoRequest struct {
+	Email     string   `json:"email"`
+	Alias     string   `json:"alias"`
+	Password  string   `json:"password"`
+	FCMToken  string   `json:"fcm_token"`
+	Latitude  *float64 `json:"latitude"`
+	Longitude *float64 `json:"longitude"`
+}
+
+type RegisterCiudadanoUseCase struct {
+	postgresRepo ports.CiudadanoPostgresRepository
+	redisRepo    ports.CiudadanoRepository
+}
+
+func NewRegisterCiudadanoUseCase(
+	postgresRepo ports.CiudadanoPostgresRepository,
+	redisRepo ports.CiudadanoRepository,
+) *RegisterCiudadanoUseCase {
+	return &RegisterCiudadanoUseCase{postgresRepo: postgresRepo, redisRepo: redisRepo}
+}
+
+func (uc *RegisterCiudadanoUseCase) Execute(ctx context.Context, req RegisterCiudadanoRequest) (int, error) {
+	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
+
+	existing, err := uc.postgresRepo.FindByEmail(ctx, req.Email)
+	if err != nil {
+		return 0, err
+	}
+	if existing != nil {
+		return 0, errors.New("email ya registrado")
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return 0, err
+	}
+
+	ciudadano := &entities.CiudadanoPostgres{
+		Email:        req.Email,
+		Alias:        strings.TrimSpace(req.Alias),
+		PasswordHash: string(hash),
+	}
+
+	id, err := uc.postgresRepo.Create(ctx, ciudadano)
+	if err != nil {
+		return 0, err
+	}
+
+	userIDStr := fmt.Sprintf("%d", id)
+
+	if req.Latitude != nil && req.Longitude != nil {
+		if err := uc.redisRepo.RegisterUser(ctx, userIDStr, *req.Longitude, *req.Latitude, req.FCMToken); err != nil {
+			return id, err
+		}
+	} else {
+		if err := uc.redisRepo.UpdateUserFCMToken(ctx, userIDStr, req.FCMToken); err != nil {
+			return id, err
+		}
+	}
+
+	return id, nil
+}

--- a/src/ciudadano/application/update_coordinates.go
+++ b/src/ciudadano/application/update_coordinates.go
@@ -1,0 +1,40 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vicpoo/API_recolecta/src/ciudadano/domain/ports"
+)
+
+type UpdateCoordinatesRequest struct {
+	UserID    int
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+type UpdateCoordinatesUseCase struct {
+	redisRepo    ports.CiudadanoRepository
+	postgresRepo ports.CiudadanoPostgresRepository
+}
+
+func NewUpdateCoordinatesUseCase(
+	redisRepo ports.CiudadanoRepository,
+	postgresRepo ports.CiudadanoPostgresRepository,
+) *UpdateCoordinatesUseCase {
+	return &UpdateCoordinatesUseCase{redisRepo: redisRepo, postgresRepo: postgresRepo}
+}
+
+func (uc *UpdateCoordinatesUseCase) Execute(ctx context.Context, req UpdateCoordinatesRequest) error {
+	citizen, err := uc.postgresRepo.FindByID(ctx, req.UserID)
+	if err != nil {
+		return err
+	}
+	if citizen == nil {
+		return errors.New("ciudadano no encontrado")
+	}
+
+	userIDStr := fmt.Sprintf("%d", req.UserID)
+	return uc.redisRepo.UpdateUserGeoCoordinates(ctx, userIDStr, req.Longitude, req.Latitude)
+}

--- a/src/ciudadano/domain/entities/ciudadano_postgres.go
+++ b/src/ciudadano/domain/entities/ciudadano_postgres.go
@@ -1,0 +1,12 @@
+package entities
+
+import "time"
+
+type CiudadanoPostgres struct {
+	ID           int       `json:"id"`
+	Email        string    `json:"email"`
+	Alias        string    `json:"alias"`
+	PasswordHash string    `json:"-"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}

--- a/src/ciudadano/domain/ports/ciudadano_postgres_repository.go
+++ b/src/ciudadano/domain/ports/ciudadano_postgres_repository.go
@@ -1,0 +1,13 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/vicpoo/API_recolecta/src/ciudadano/domain/entities"
+)
+
+type CiudadanoPostgresRepository interface {
+	Create(ctx context.Context, u *entities.CiudadanoPostgres) (int, error)
+	FindByEmail(ctx context.Context, email string) (*entities.CiudadanoPostgres, error)
+	FindByID(ctx context.Context, id int) (*entities.CiudadanoPostgres, error)
+}

--- a/src/ciudadano/infrastructure/dependencies.go
+++ b/src/ciudadano/infrastructure/dependencies.go
@@ -1,0 +1,26 @@
+package infrastructure
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+	goredis "github.com/redis/go-redis/v9"
+	ciudadanoApp "github.com/vicpoo/API_recolecta/src/ciudadano/application"
+	ciudadanoHttp "github.com/vicpoo/API_recolecta/src/ciudadano/infrastructure/http"
+	ciudadanoPostgres "github.com/vicpoo/API_recolecta/src/ciudadano/infrastructure/postgres"
+	ciudadanoRedis "github.com/vicpoo/API_recolecta/src/ciudadano/infrastructure/redis"
+)
+
+type CiudadanoDependencies struct {
+	Controller *ciudadanoHttp.CiudadanoController
+}
+
+func NewCiudadanoDependencies(db *pgxpool.Pool, rdb *goredis.Client) *CiudadanoDependencies {
+	postgresRepo := ciudadanoPostgres.NewPostgresCiudadanoRepository(db)
+	redisRepo := ciudadanoRedis.NewRedisCiudadanoRepository(rdb)
+
+	registerUC := ciudadanoApp.NewRegisterCiudadanoUseCase(postgresRepo, redisRepo)
+	updateCoordUC := ciudadanoApp.NewUpdateCoordinatesUseCase(redisRepo, postgresRepo)
+
+	controller := ciudadanoHttp.NewCiudadanoController(registerUC, updateCoordUC)
+
+	return &CiudadanoDependencies{Controller: controller}
+}

--- a/src/ciudadano/infrastructure/http/ciudadano_controller.go
+++ b/src/ciudadano/infrastructure/http/ciudadano_controller.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/vicpoo/API_recolecta/src/ciudadano/application"
+	"github.com/vicpoo/API_recolecta/src/core"
+)
+
+type CiudadanoController struct {
+	registerUC      *application.RegisterCiudadanoUseCase
+	updateCoordUC   *application.UpdateCoordinatesUseCase
+}
+
+func NewCiudadanoController(
+	registerUC *application.RegisterCiudadanoUseCase,
+	updateCoordUC *application.UpdateCoordinatesUseCase,
+) *CiudadanoController {
+	return &CiudadanoController{registerUC: registerUC, updateCoordUC: updateCoordUC}
+}
+
+func (ctrl *CiudadanoController) RegisterRoutes(r *gin.Engine) {
+	public := r.Group("/api/ciudadanos")
+	{
+		public.POST("/register", ctrl.Register)
+	}
+
+	protected := r.Group("/api/ciudadanos", core.JWTAuthMiddleware())
+	{
+		protected.POST("/coordinates", ctrl.UpdateCoordinates)
+	}
+}
+
+func (ctrl *CiudadanoController) Register(ctx *gin.Context) {
+	var body application.RegisterCiudadanoRequest
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, err := ctrl.registerUC.Execute(ctx, body)
+	if err != nil {
+		if err.Error() == "email ya registrado" {
+			ctx.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	token, err := core.GenerateToken(id, core.CIUDADANO)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error al generar token"})
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, gin.H{"id": id, "token": token})
+}
+
+type updateCoordinatesBody struct {
+	Latitude  float64 `json:"latitude" binding:"required"`
+	Longitude float64 `json:"longitude" binding:"required"`
+}
+
+func (ctrl *CiudadanoController) UpdateCoordinates(ctx *gin.Context) {
+	var body updateCoordinatesBody
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userID := ctx.GetInt("user_id")
+
+	err := ctrl.updateCoordUC.Execute(ctx, application.UpdateCoordinatesRequest{
+		UserID:    userID,
+		Latitude:  body.Latitude,
+		Longitude: body.Longitude,
+	})
+	if err != nil {
+		if err.Error() == "ciudadano no encontrado" {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.Status(http.StatusOK)
+}

--- a/src/ciudadano/infrastructure/postgres/postgres_ciudadano_repository.go
+++ b/src/ciudadano/infrastructure/postgres/postgres_ciudadano_repository.go
@@ -1,0 +1,68 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/vicpoo/API_recolecta/src/ciudadano/domain/entities"
+	"github.com/vicpoo/API_recolecta/src/ciudadano/domain/ports"
+)
+
+type PostgresCiudadanoRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewPostgresCiudadanoRepository(db *pgxpool.Pool) ports.CiudadanoPostgresRepository {
+	return &PostgresCiudadanoRepository{db: db}
+}
+
+func (r *PostgresCiudadanoRepository) Create(ctx context.Context, u *entities.CiudadanoPostgres) (int, error) {
+	const q = `
+		INSERT INTO ciudadano (email, alias, password, created_at, updated_at)
+		VALUES ($1, $2, $3, NOW(), NOW())
+		RETURNING id
+	`
+	var id int
+	err := r.db.QueryRow(ctx, q, u.Email, u.Alias, u.PasswordHash).Scan(&id)
+	return id, err
+}
+
+func (r *PostgresCiudadanoRepository) FindByEmail(ctx context.Context, email string) (*entities.CiudadanoPostgres, error) {
+	const q = `
+		SELECT id, email, alias, password, created_at, updated_at
+		FROM ciudadano
+		WHERE email = $1
+	`
+	var u entities.CiudadanoPostgres
+	err := r.db.QueryRow(ctx, q, email).Scan(
+		&u.ID, &u.Email, &u.Alias, &u.PasswordHash, &u.CreatedAt, &u.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *PostgresCiudadanoRepository) FindByID(ctx context.Context, id int) (*entities.CiudadanoPostgres, error) {
+	const q = `
+		SELECT id, email, alias, password, created_at, updated_at
+		FROM ciudadano
+		WHERE id = $1
+	`
+	var u entities.CiudadanoPostgres
+	err := r.db.QueryRow(ctx, q, id).Scan(
+		&u.ID, &u.Email, &u.Alias, &u.PasswordHash, &u.CreatedAt, &u.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &u, nil
+}

--- a/src/ciudadano/infrastructure/routes.go
+++ b/src/ciudadano/infrastructure/routes.go
@@ -1,0 +1,7 @@
+package infrastructure
+
+import "github.com/gin-gonic/gin"
+
+func RegisterCiudadanoRoutes(engine *gin.Engine, deps *CiudadanoDependencies) {
+	deps.Controller.RegisterRoutes(engine)
+}


### PR DESCRIPTION
- Implementación de entidades para modelado de datos a utilizar en PostgreSQL conforme a ciudadanos.
- Ruta e implementación de lógica para registrar ciudadanos.
- Flexibilidad para registrar ciudadanos con o sin geolocalización, tokens FCM son obligatorios.
- Repositorio de ciudadanos usando PostgreSQL.
- Caso de uso para actualizar coordenadas.
- Creación del controlador de ciudadanos con endpoint para registrar ciudadanos y actualizar coordenada